### PR TITLE
PERF never memmap arrays in joblib

### DIFF
--- a/pizza_cutter_metadetect/run_metadetect.py
+++ b/pizza_cutter_metadetect/run_metadetect.py
@@ -473,6 +473,7 @@ def run_metadetect(
             verbose=100,
             n_jobs=n_jobs,
             pre_dispatch='2*n_jobs',
+            max_nbytes=None,  # never memmap
         )(
             joblib.delayed(_do_metadetect)(
                 config, mbobs, gaia_stars, seed+i*256, i, preconfig, shear_bands,


### PR DESCRIPTION
This PR tuns off joblib mem mapping for arrays since it hits disk in weird ways.