### PR TITLE
BUG truncate negative mfracs and weights

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
             flake8 \
             pytest \
             pytest-xdist \
-            "numba<0.54.0"
+            "numba!=0.54.0"
 
       - name: lint
         shell: bash -l {0}
@@ -47,4 +47,4 @@ jobs:
         run: |
           git clone https://github.com/beckermr/des-y3-test-data.git
           export TEST_DESDATA=`pwd`/des-y3-test-data
-          pytest -vv pizza_cutter_metadetect
+          pytest -n 4 -vv pizza_cutter_metadetect

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,6 @@ jobs:
           mamba install -y -q \
             flake8 \
             pytest \
-            pytest-xdist \
             "numba!=0.54.0"
 
       - name: lint
@@ -47,4 +46,4 @@ jobs:
         run: |
           git clone https://github.com/beckermr/des-y3-test-data.git
           export TEST_DESDATA=`pwd`/des-y3-test-data
-          pytest -n 4 -vv pizza_cutter_metadetect
+          pytest -vv pizza_cutter_metadetect

--- a/pizza_cutter_metadetect/tests/test_run_metadetect.py
+++ b/pizza_cutter_metadetect/tests/test_run_metadetect.py
@@ -98,6 +98,7 @@ def make_sim(
     dens=100,
     ngrid=7,
     snr=1e6,
+    neg_mfrac=False,
 ):
     rng = np.random.RandomState(seed=seed)
 
@@ -160,7 +161,9 @@ def make_sim(
                 image=psf_im,
                 jacobian=psf_jac,
             ),
-            mfrac=rng.normal(size=im.shape, scale=0.1),
+            mfrac=rng.normal(size=im.shape, scale=0.1) * (
+                1 if neg_mfrac else 0
+            ),
         )
         obslist = ngmix.ObsList()
         obslist.append(obs)
@@ -600,7 +603,9 @@ def test_do_metadetect_pos_mfrac():
     preconfig = None
     mdet_seed = 12
 
-    mbobs = make_sim(seed=seed, nbands=3, g1=0.02, g2=0.00, ngrid=7, snr=1e6)
+    mbobs = make_sim(
+        seed=seed, nbands=3, g1=0.02, g2=0.00, ngrid=7, snr=1e6, neg_mfrac=True
+    )
     res = _do_metadetect(
         CONFIG, mbobs, gaia_stars, mdet_seed, i, preconfig, [True, True, True],
     )

--- a/pizza_cutter_metadetect/tests/test_run_metadetect.py
+++ b/pizza_cutter_metadetect/tests/test_run_metadetect.py
@@ -160,6 +160,7 @@ def make_sim(
                 image=psf_im,
                 jacobian=psf_jac,
             ),
+            mfrac=rng.normal(size=im.shape, scale=0.1),
         )
         obslist = ngmix.ObsList()
         obslist.append(obs)
@@ -590,6 +591,22 @@ def test_do_metadetect_shear_bands():
                 res1[0][key][col],
                 res2[0][key][col],
             )
+
+
+def test_do_metadetect_pos_mfrac():
+    gaia_stars = None
+    seed = 10
+    i = 10
+    preconfig = None
+    mdet_seed = 12
+
+    mbobs = make_sim(seed=seed, nbands=3, g1=0.02, g2=0.00, ngrid=7, snr=1e6)
+    res = _do_metadetect(
+        CONFIG, mbobs, gaia_stars, mdet_seed, i, preconfig, [True, True, True],
+    )
+
+    for key in ['noshear', '1p', '1m', '2p', '2m']:
+        assert np.all(res[0][key]["mfrac"] >= 0)
 
 
 @pytest.mark.parametrize("wmul", [

--- a/pizza_cutter_metadetect/tests/test_run_metadetect.py
+++ b/pizza_cutter_metadetect/tests/test_run_metadetect.py
@@ -552,7 +552,7 @@ def test_do_metadetect(shear_bands):
     )
 
     assert np.abs(m) < max(1e-3, 3*merr)
-    assert np.abs(c) < 3*cerr
+    assert np.abs(c) < max(1e-6, 3*cerr)
 
 
 def test_do_metadetect_shear_bands():


### PR DESCRIPTION
This PR truncates negative mfracs and weights. These happen when small, but non-zero values get packed.

closes #25 